### PR TITLE
変数出力の方法をPHP8.2.xに合わせて修正

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -210,7 +210,7 @@ class Engine
         $sql->addWhereOpr('relation_bid', $targetBid);
         $lang = DB::query($sql->get(dsn()), 'one');
         $categoryField = loadCategoryField($cid);
-        if ($exceptionCode = $categoryField->get("google_translate_relation_category_${lang}_code", false)) {
+        if ($exceptionCode = $categoryField->get("google_translate_relation_category_{$lang}_code", false)) {
             $code = $exceptionCode;
         }
 


### PR DESCRIPTION
PHPでは ${var} と {$var} ともに利用できるみたいですが、php.iniでの設定や、PHPのバージョンによって${var}が使えないケースがあるようです。ですので、{$var}に変更しました。